### PR TITLE
Fix: 'libpng12-dev' has no installation candidate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:5.6-apache
 MAINTAINER Maksym Prokopov<mprokopov@gmail.com>
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev unzip git \
+RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libmcrypt-dev unzip git \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install gd mcrypt mbstring mysqli pdo_mysql zip


### PR DESCRIPTION
The package libpng12-dev was dropped after 16.04. It's been gone a long time.

Try libpng-dev

https://askubuntu.com/a/991711